### PR TITLE
fix: label contracts, upgrade pnpm, and secure images

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -17,6 +17,8 @@ runs:
 
     - name: Install pnpm
       uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      with:
+        version: 11.13.0
 
     - name: Install Foundry
       if: ${{ inputs.install-foundry == 'true' }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -61,56 +61,14 @@ jobs:
       - name: Tag snapshot monitor image for scan
         run: pnpm run docker:tag:scan:snapshot-monitor
 
-      - name: Scan indexer Dockerfile for misconfigurations
+      - name: Scan Dockerfiles for misconfigurations
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        env:
+          TRIVY_FILE_PATTERNS: dockerfile:Dockerfile-*
+          TRIVY_SKIP_DIRS: node_modules
         with:
           scan-type: config
-          scan-ref: Dockerfile-indexer
-          scanners: misconfig
-          severity: MEDIUM,HIGH,CRITICAL
-          exit-code: "1"
-
-      - name: Scan frontend Dockerfile for misconfigurations
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
-        with:
-          scan-type: config
-          scan-ref: Dockerfile-frontend
-          scanners: misconfig
-          severity: MEDIUM,HIGH,CRITICAL
-          exit-code: "1"
-
-      - name: Scan Hasura Dockerfile for misconfigurations
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
-        with:
-          scan-type: config
-          scan-ref: Dockerfile-hasura
-          scanners: misconfig
-          severity: MEDIUM,HIGH,CRITICAL
-          exit-code: "1"
-
-      - name: Scan snapshot gateway Dockerfile for misconfigurations
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
-        with:
-          scan-type: config
-          scan-ref: Dockerfile-snapshot-gateway
-          scanners: misconfig
-          severity: MEDIUM,HIGH,CRITICAL
-          exit-code: "1"
-
-      - name: Scan snapshot publisher Dockerfile for misconfigurations
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
-        with:
-          scan-type: config
-          scan-ref: Dockerfile-snapshot-publisher
-          scanners: misconfig
-          severity: MEDIUM,HIGH,CRITICAL
-          exit-code: "1"
-
-      - name: Scan snapshot monitor Dockerfile for misconfigurations
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
-        with:
-          scan-type: config
-          scan-ref: Dockerfile-snapshot-monitor
+          scan-ref: .
           scanners: misconfig
           severity: MEDIUM,HIGH,CRITICAL
           exit-code: "1"

--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -32,7 +32,7 @@ FROM nginxinc/nginx-unprivileged:alpine@sha256:601c823234c474696ded03d619e67f1e5
 
 # Apply Alpine security updates
 USER root
-RUN apk upgrade --no-cache curl libcurl musl musl-utils zlib libssl3 libcrypto3 libuuid libpng libxpm libxml2 nghttp2-libs xz-libs
+RUN apk upgrade --no-cache c-ares curl libcurl libexpat musl musl-utils zlib libssl3 libcrypto3 libuuid libpng libxpm libxml2 nghttp2-libs xz-libs
 
 # Copy the built static files to Nginx's serve directory
 COPY --from=builder /app/apps/frontend/dist /usr/share/nginx/html

--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -2,7 +2,7 @@
 FROM node:24-alpine@sha256:01743339035a5c3c11a373cd7c83aeab6ed1457b55da6a69e014a95ac4e4700b AS builder
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 
 # Set working directory
 WORKDIR /app

--- a/Dockerfile-hasura
+++ b/Dockerfile-hasura
@@ -7,6 +7,7 @@ RUN apt-get update \
     && ACCEPT_EULA=Y DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --only-upgrade \
         coreutils \
         curl \
+        gzip \
         libcap2 \
         libcurl4 \
         libexpat1 \
@@ -14,9 +15,11 @@ RUN apt-get update \
         libgnutls30 \
         liblzma5 \
         libnghttp2-14 \
+        libperl5.34 \
         libpq5 \
         libpython3.10-minimal \
         libpython3.10-stdlib \
+        libsqlite3-0 \
         libssh-4 \
         libssl3 \
         libsystemd0 \
@@ -24,10 +27,14 @@ RUN apt-get update \
         libuuid1 \
         msodbcsql18 \
         openssl \
+        perl \
+        perl-base \
+        perl-modules-5.34 \
         postgresql-client-common \
         python3.10 \
         python3.10-minimal \
         sed \
+        tar \
         util-linux \
     && rm -rf /var/lib/apt/lists/* \
     && chown -R hasura:hasura /home/hasura

--- a/Dockerfile-indexer
+++ b/Dockerfile-indexer
@@ -3,7 +3,7 @@
 FROM node:24-slim@sha256:242549cd46785b480c832479a730f4f2a20865d61ea2e404fdb2a5c3d3b73ecf AS deps
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 
 # Set working directory
 WORKDIR /app

--- a/Dockerfile-snapshot-gateway
+++ b/Dockerfile-snapshot-gateway
@@ -4,7 +4,7 @@ FROM node:24-alpine@sha256:01743339035a5c3c11a373cd7c83aeab6ed1457b55da6a69e014a
 
 RUN apk upgrade --no-cache musl musl-utils zlib libssl3 libcrypto3 nghttp2-libs xz-libs
 
-RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 
 WORKDIR /app
 

--- a/Dockerfile-snapshot-monitor
+++ b/Dockerfile-snapshot-monitor
@@ -4,7 +4,7 @@ FROM node:24-alpine@sha256:01743339035a5c3c11a373cd7c83aeab6ed1457b55da6a69e014a
 
 RUN apk upgrade --no-cache musl musl-utils zlib libssl3 libcrypto3 nghttp2-libs xz-libs
 
-RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 
 WORKDIR /app
 

--- a/Dockerfile-snapshot-publisher
+++ b/Dockerfile-snapshot-publisher
@@ -4,7 +4,7 @@ FROM node:24-alpine@sha256:01743339035a5c3c11a373cd7c83aeab6ed1457b55da6a69e014a
 
 RUN apk upgrade --no-cache musl musl-utils zlib libssl3 libcrypto3 nghttp2-libs xz-libs
 
-RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 
 WORKDIR /app
 

--- a/apps/indexer/README.md
+++ b/apps/indexer/README.md
@@ -22,7 +22,7 @@ surface effect metrics for those reads.
 ## Prerequisites
 
 - Node.js 24
-- pnpm 10.33.0
+- pnpm 11.13.0
 - Docker Desktop, for the local Envio Postgres/Hasura stack
 - RPC URLs for the enabled chains
 - `ENVIO_API_TOKEN` is strongly recommended and required by the local Docker

--- a/apps/indexer/src/ContractNames.ts
+++ b/apps/indexer/src/ContractNames.ts
@@ -294,6 +294,11 @@ const contractNames: MultiChainContracts = {
       name: "PriceConfig",
       type: "policy",
     },
+    "0x5c69f61D384e41b55699C3B10523Ed81c5ef9cbd": {
+      name: "PriceConfig",
+      version: "2.0",
+      type: "policy",
+    },
     "0xf7602C0421c283A2fc113172EBDf64C30F21654D": {
       name: "Heart",
       version: "1.6",
@@ -450,6 +455,9 @@ const contractNames: MultiChainContracts = {
     "0x012BBf0481b97170577745D2167ee14f63E2aD4C": {
       name: "DAO MS",
     },
+    "0xa8A6ff2606b24F61AFA986381D8991DFcCCd2D55": {
+      name: "Emergency MS",
+    },
     "0x20B3834091f038Ce04D8686FAC99CA44A0FB285c": {
       name: "CrossChainBridge",
       type: "policy",
@@ -490,6 +498,9 @@ const contractNames: MultiChainContracts = {
     },
     "0x18a390bD45bCc92652b9A91AD51Aed7f1c1358f5": {
       name: "DAO MS",
+    },
+    "0xa8A6ff2606b24F61AFA986381D8991DFcCCd2D55": {
+      name: "Emergency MS",
     },
     "0x22ae99d07584a2ae1af748de573c83f1b9cdb4c0": {
       name: "CrossChainBridge",
@@ -538,6 +549,9 @@ const contractNames: MultiChainContracts = {
       name: "DAO MS",
     },
     "0xa5ea62894027D981D34BB99A04BD36B818b2Aaf0": {
+      name: "Emergency MS (Deprecated)",
+    },
+    "0xa8A6ff2606b24F61AFA986381D8991DFcCCd2D55": {
       name: "Emergency MS",
     },
     "0xBA42BE149e5260EbA4B82418A6306f55D532eA47": {
@@ -585,6 +599,9 @@ const contractNames: MultiChainContracts = {
     "0x559a14a2219Ae81f9a9f857CF31407de2b07F36c": {
       name: "DAO MS",
       type: "external",
+    },
+    "0xa8A6ff2606b24F61AFA986381D8991DFcCCd2D55": {
+      name: "Emergency MS",
     },
     "0x22AE99D07584A2AE1af748De573c83f1B9Cdb4c0": {
       name: "CrossChainBridge",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "protocol-visualizer",
   "private": true,
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.13.0",
   "scripts": {
     "build": "turbo run build && pnpm run test:config",
     "check:runtime-versions": "node scripts/verify-runtime-versions.mjs",
@@ -50,7 +50,7 @@
   ],
   "engines": {
     "node": ">=24",
-    "pnpm": ">=10.33.0",
+    "pnpm": ">=11.13.0",
     "bun": "use-pnpm",
     "npm": "use-pnpm",
     "yarn": "use-pnpm"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -86,6 +86,6 @@ overrides:
   "vitest@<4.1.8": "4.1.8"
   "ws@>=8.0.0 <8.21.0": "^8.21.0"
   "yaml@<2.8.3": "2.8.3"
-onlyBuiltDependencies:
-  - "better-sqlite3@9.6.0"
-  - "esbuild@0.28.1"
+allowBuilds:
+  "better-sqlite3@9.6.0": true
+  "esbuild@0.28.1": true

--- a/tests/config.test.mjs
+++ b/tests/config.test.mjs
@@ -85,8 +85,10 @@ test("CI scans every Dockerfile and local image", () => {
     "Dockerfile-snapshot-publisher",
     "Dockerfile-snapshot-monitor",
   ]) {
-    assert(workflow.includes(dockerfile));
+    assert(existsSync(dockerfile));
   }
+  assert.match(workflow, /TRIVY_FILE_PATTERNS: dockerfile:Dockerfile-\*/);
+  assert.match(workflow, /TRIVY_SKIP_DIRS: node_modules/);
   assert.match(
     workflow,
     /image-ref: protocol-visualizer\/indexer:scan[\s\S]*?ignore-unfixed: true/


### PR DESCRIPTION
## Summary

Newly deployed PriceConfig v2 and Emergency multisig contracts no longer appear as unknown in the protocol visualizer, while retired L2 multisigs are explicitly marked as deprecated across the supported deployment maps.

The branch also upgrades local, CI, and Docker tooling to pnpm 11.13.0 while preserving the strict dependency build-script allowlist. Frontend and Hasura images now install patched operating-system packages, and the security workflow scans all six nonstandard Dockerfile names instead of silently detecting zero files.

## Validation

- A normal `corepack pnpm install` completes without changing `pnpm-lock.yaml`.
- Clean installs pass with both `--no-frozen-lockfile` and `--frozen-lockfile`.
- Runtime-version alignment, lint, workspace builds, and tests pass.
- The rebuilt frontend and Hasura images pass Trivy v0.69.3 with zero Medium, High, or Critical vulnerabilities and zero detected secrets.
- The corrected configuration scan detects all six repository Dockerfiles with zero misconfigurations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Upgraded the required pnpm/tooling version to **11.13.0** across repo settings and container builds.
  * Refreshed the indexer prerequisites docs and the pnpm workspace build configuration for native dependencies.
  * Expanded OS dependency upgrades for the Hasura image and updated frontend container package upgrades.
* **Data Updates**
  * Updated indexer contract mappings, including new **Emergency MS** entries and a **deprecated** Berachain Emergency MS record.
* **Security / CI**
  * Consolidated Dockerfile security scanning into a single repository-wide Trivy config scan.
* **Tests**
  * Updated CI scan assertions to validate expected scanning patterns rather than per-file workflow text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->