### PR TITLE
fix(deps): patch brace-expansion denial of service

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   bn.js@>=5.0.0 <5.2.3: 5.2.3
   brace-expansion@<1.1.13: 1.1.13
   brace-expansion@>=2.0.0 <2.0.3: 2.0.3
-  brace-expansion@>=5.0.0 <5.0.6: 5.0.6
+  brace-expansion@>=5.0.0 <5.0.7: 5.0.7
   drizzle-orm@<0.45.2: 0.45.2
   esbuild@>=0.17.0 <0.28.1: ^0.28.1
   express@>=4.0.0 <4.22.2: 4.22.2
@@ -1407,8 +1407,8 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -4417,7 +4417,7 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5168,7 +5168,7 @@ snapshots:
 
   minimatch@9.0.7:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,7 +63,7 @@ overrides:
   "bn.js@>=5.0.0 <5.2.3": "5.2.3"
   "brace-expansion@<1.1.13": "1.1.13"
   "brace-expansion@>=2.0.0 <2.0.3": "2.0.3"
-  "brace-expansion@>=5.0.0 <5.0.6": "5.0.6"
+  "brace-expansion@>=5.0.0 <5.0.7": "5.0.7"
   "drizzle-orm@<0.45.2": "0.45.2"
   "esbuild@>=0.17.0 <0.28.1": "^0.28.1"
   "express@>=4.0.0 <4.22.2": "4.22.2"


### PR DESCRIPTION
## Summary

Protocol Visualizer's moderate-or-higher dependency audit is clean again: the vulnerable `brace-expansion` copy in the frontend toolchain now resolves to patched version `5.0.7` while retaining the existing bounded override policy.

## Validation

- `CI=true pnpm install --frozen-lockfile`
- `pnpm audit --audit-level moderate` (passes; one low-severity `body-parser` advisory remains below policy)
- Runtime-version check, lint, build/tests, local snapshot generation, and indexer/frontend image builds passed
- Snapshot-gateway image build was killed with exit 137 during Docker metadata resolution; the mandated sequence stopped there, so the snapshot-publisher image build was not run
- Local CodeRabbit preflight was unavailable because the organization review quota was rate-limited
